### PR TITLE
feat(users): add delete functionality with toast notifications

### DIFF
--- a/client/src/app/modules/users/components/UsersTable.tsx
+++ b/client/src/app/modules/users/components/UsersTable.tsx
@@ -2,15 +2,60 @@
 
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
+import { Button } from 'primereact/button';
+import { confirmDialog } from 'primereact/confirmdialog';
 import { User } from '../types';
 
 interface UsersTableProps {
   users: User[];
   loading?: boolean;
   onRowSelect?: (user: User) => void;
+  onDelete?: (user: User) => void;
+  deletingUserId?: string; // ID del usuario que se está eliminando
 }
 
-export const UsersTable: React.FC<UsersTableProps> = ({ users, loading = false, onRowSelect }) => {
+export const UsersTable: React.FC<UsersTableProps> = ({
+  users,
+  loading = false,
+  onRowSelect,
+  onDelete,
+  deletingUserId,
+}) => {
+  const handleDeleteClick = (user: User, event: React.MouseEvent) => {
+    event.stopPropagation();
+
+    confirmDialog({
+      message: `¿Estás seguro que deseas eliminar al usuario "${user.usuario}"?`,
+      header: 'Confirmar eliminación',
+      icon: 'pi pi-exclamation-triangle',
+      acceptClassName: 'p-button-danger',
+      acceptLabel: 'Eliminar',
+      rejectLabel: 'Cancelar',
+      accept: () => {
+        onDelete?.(user);
+      },
+    });
+  };
+
+  const actionBodyTemplate = (rowData: User) => {
+    const isDeleting = deletingUserId === rowData.id;
+
+    return (
+      <div className="flex justify-content-center">
+        <Button
+          icon={isDeleting ? 'pi pi-spin pi-spinner' : 'pi pi-trash'}
+          className={`p-button-rounded p-button-text ${
+            isDeleting ? 'p-button-secondary' : 'p-button-danger'
+          }`}
+          onClick={(e) => handleDeleteClick(rowData, e)}
+          tooltip={isDeleting ? 'Eliminando...' : 'Eliminar usuario'}
+          tooltipOptions={{ position: 'top' }}
+          disabled={isDeleting}
+        />
+      </div>
+    );
+  };
+
   return (
     <DataTable<User[]>
       value={users}
@@ -19,11 +64,12 @@ export const UsersTable: React.FC<UsersTableProps> = ({ users, loading = false, 
       onRowClick={(e) => onRowSelect?.(e.data as User)}
       className="cursor-pointer"
     >
-      <Column field="id" header="ID" sortable style={{ width: '25%' }} />
+      <Column field="id" header="ID" sortable style={{ width: '20%' }} />
       <Column
         field="usuario"
         header="Usuario"
         sortable
+        style={{ width: '30%' }}
         body={(row) => (
           <p className="text-primary underline font-bold custom-capitalize">{row.usuario}</p>
         )}
@@ -32,13 +78,21 @@ export const UsersTable: React.FC<UsersTableProps> = ({ users, loading = false, 
         field="estado"
         header="Estado"
         sortable
+        style={{ width: '20%' }}
         body={(row) => <p className="custom-capitalize secondary-table-text">{row.estado}</p>}
       />
       <Column
         field="sector"
         header="Sector"
         sortable
+        style={{ width: '20%' }}
         body={(row) => <p className="custom-capitalize secondary-table-text">{row.sector}</p>}
+      />
+      <Column
+        header="Acciones"
+        body={actionBodyTemplate}
+        style={{ width: '10%' }}
+        className="text-center"
       />
     </DataTable>
   );

--- a/client/src/app/modules/users/containers/ClientTableContainer.tsx
+++ b/client/src/app/modules/users/containers/ClientTableContainer.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
+import { ConfirmDialog } from 'primereact/confirmdialog';
+import { Toast } from 'primereact/toast';
+import { useRef } from 'react';
 import { UsersTable } from '../components/UsersTable';
 import type { ListUsersParams, User } from '../types';
 import { UserStatus } from '../constants';
 import Pagination from '@/app/components/organisms/Pagination';
 import { useUserFormContext } from '../context/UserFormContext';
-import { useGetUsers } from '../hooks/useUsers';
+import { useGetUsers, useDeleteUser } from '../hooks/useUsers';
 
 interface Props {
   ssrUsers: User[]; // datos pre-renderizados desde el servidor
@@ -15,13 +18,19 @@ interface Props {
 }
 
 export default function UsersTableClient({ ssrUsers, ssrTotal, initialParams }: Props) {
+  // Ref para las notificaciones toast
+  const toast = useRef<Toast>(null);
+
   // 1) Tomamos la función openEdit del contexto del layout
   const { openEdit } = useUserFormContext();
 
-  // 2) Leemos la URL actual (query params) en el cliente
+  // 2) Hook para eliminar usuarios
+  const deleteUser = useDeleteUser();
+
+  // 3) Leemos la URL actual (query params) en el cliente
   const searchParams = useSearchParams();
 
-  // 3) Reconstruimos los parámetros de consulta a partir de la URL,
+  // 4) Reconstruimos los parámetros de consulta a partir de la URL,
   //    cayendo en initialParams si no existen en la queryString.
   const params: ListUsersParams = {
     page: Math.max(1, Number(searchParams.get('page') ?? initialParams.page) || 1),
@@ -31,24 +40,53 @@ export default function UsersTableClient({ ssrUsers, ssrTotal, initialParams }: 
     sector: searchParams.get('sector') ? Number(searchParams.get('sector')) : initialParams.sector,
   };
 
-  // 4) React-Query hook:
+  // 5) React-Query hook:
   //    - placeholderData = ssrUsers: usamos los datos de SSR como punto de partida
   //    - dispara un refetch al montarse/re-montarse con los nuevos params
   //    - nos devuelve `data` y `isLoading` para manejar estado de carga
   const { data: users = [], isLoading } = useGetUsers(params, ssrUsers);
 
+  // 6) Función para manejar la eliminación de usuarios
+  const handleDeleteUser = async (user: User) => {
+    try {
+      await deleteUser.mutateAsync(user.id);
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Usuario eliminado',
+        detail: `El usuario "${user.usuario}" ha sido eliminado exitosamente`,
+        life: 3000,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (error) {
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'No se pudo eliminar el usuario. Inténtalo de nuevo.',
+        life: 3000,
+      });
+    }
+  };
+
   return (
     <>
-      {/* 5) Tabla interactiva */}
+      {/* Toast para notificaciones */}
+      <Toast ref={toast} />
+
+      {/* Modal de confirmación para eliminación */}
+      <ConfirmDialog />
+
+      {/* 7) Tabla interactiva */}
       <UsersTable
         users={users}
         loading={isLoading}
         onRowSelect={(selectedUser) => {
           openEdit(selectedUser);
         }}
+        onDelete={handleDeleteUser}
+        deletingUserId={deleteUser.isPending ? deleteUser.variables : undefined}
       />
 
-      {/* 6) Paginador */}
+      {/* 8) Paginador */}
       <Pagination totalRecords={ssrTotal} />
     </>
   );

--- a/client/src/app/modules/users/hooks/useUsers.ts
+++ b/client/src/app/modules/users/hooks/useUsers.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CreateUserDto, ListUsersParams, UpdateUserDto, User } from '../types';
 import { usersService } from '../services/users.service';
-import { createUserAction, updateUserAction } from '../actions/user.actions';
+import { createUserAction, updateUserAction, deleteUserAction } from '../actions/user.actions';
 
 /**
  * Sistema centralizado de claves de query para usuarios
@@ -69,6 +69,33 @@ export function useCreateUser() {
         queryKey: userKeys.lists(),
         exact: false,
       });
+    },
+  });
+}
+
+/**
+ * Hook para eliminar usuario
+ */
+export function useDeleteUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteUserAction(id),
+    onSuccess: (_, deletedId) => {
+      // Remover el usuario específico del caché
+      queryClient.removeQueries({
+        queryKey: userKeys.detail(deletedId),
+      });
+
+      // Invalidar todas las listas para refrescar los datos
+      queryClient.invalidateQueries({
+        queryKey: userKeys.lists(),
+        exact: false,
+      });
+    },
+    onError: (error) => {
+      console.error('Error eliminando usuario:', error);
+      // Aquí podrías agregar notificación de error
     },
   });
 }

--- a/client/src/app/users/layout.tsx
+++ b/client/src/app/users/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Toast } from 'primereact/toast';
 import { Button } from '../components/atoms/Button';
 import { Header } from '../components/organisms/Header';
 import { Sidebar } from '../components/organisms/Sidebar';
@@ -19,6 +20,7 @@ export default function UsersLayout({ children }: { children: React.ReactNode })
     submitForm,
     isLoading,
     isEdit,
+    toastRef,
   } = useUserForm();
 
   return (
@@ -42,6 +44,7 @@ export default function UsersLayout({ children }: { children: React.ReactNode })
             </div>
           </div>
 
+          <Toast ref={toastRef} />
           {/* Modal crear / editar */}
           <UsersFormModal
             visible={modalOpen}


### PR DESCRIPTION
- Implement delete user action in useUsers hook with cache invalidation
- Add delete confirmation dialog and toast notifications in UsersTable
- Include toast ref in useUserForm for form submission feedback
- Update table layout to accommodate delete action column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete users directly from the users table, including a confirmation dialog for deletion.
  - Introduced toast notifications to provide feedback on user creation, update, and deletion actions.

- **Improvements**
  - Enhanced user feedback with success and error messages for user-related operations.
  - Updated the users table layout to include action buttons and improved column widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->